### PR TITLE
FreeBSD support

### DIFF
--- a/zsh-256color.plugin.zsh
+++ b/zsh-256color.plugin.zsh
@@ -13,6 +13,9 @@ _zsh_terminal_set_256color()
 				export TERM="${TERM}-256color"
 			fi
 		;;
+    darwin*)
+      export TERM="${TERM}-256color";
+    ;;
 		*)
 			for terminfos in "${HOME}/.terminfo" "/etc/terminfo" "/lib/terminfo" "/usr/share/terminfo" ; do
 				if [[ -e "$terminfos"/$TERM[1]/${TERM}-256color || \

--- a/zsh-256color.plugin.zsh
+++ b/zsh-256color.plugin.zsh
@@ -7,13 +7,22 @@ _zsh_terminal_set_256color()
 	[[ $TERM =~ "-256color$" ]] && return
 
 	# search through ncurses terminfo descriptions
-	for terminfos in "${HOME}/.terminfo" "/etc/terminfo" "/lib/terminfo" "/usr/share/terminfo" ; do
-		if [[ -e "$terminfos"/$TERM[1]/${TERM}-256color || \
-				-e "$terminfos"/${TERM}-256color ]] ; then
-			export TERM="${TERM}-256color"
-			return
-		fi
-	done
+	case $OSTYPE in
+		freebsd*)
+			if [[ -e /etc/termcap ]] && grep -q "${TERM}-256color|" /etc/termcap ; then
+				export TERM="${TERM}-256color"
+			fi
+		;;
+		*)
+			for terminfos in "${HOME}/.terminfo" "/etc/terminfo" "/lib/terminfo" "/usr/share/terminfo" ; do
+				if [[ -e "$terminfos"/$TERM[1]/${TERM}-256color || \
+						-e "$terminfos"/${TERM}-256color ]]; then
+					export TERM="${TERM}-256color"
+					return
+				fi
+			done
+		;;
+	esac
 }
 
 _zsh_terminal_set_256color


### PR DESCRIPTION
FreeBSD ncurses uses termcap instead of terminfo
